### PR TITLE
Fix IncidentID2RuleName.txt

### DIFF
--- a/IncidentID2RuleName.txt
+++ b/IncidentID2RuleName.txt
@@ -1,7 +1,17 @@
 //Getting the Analytics Rule name from the Incident ID
 
-SecurityAlert
-| where TimeGenerated >= (90d)
-| extend RuleID = parse_json(tostring(parse_json(ExtendedProperties).["Analytic Rule Ids"]))[0]
-| where ProviderName contains "ASI" and RuleID contains "<enter your Incident ID here>"
-| distinct DisplayName
+SecurityIncident
+| where TimeGenerated >= ago(90d)
+| where IncidentNumber == toint("<enter your Incident ID here>")
+| summarize arg_max(TimeGenerated, IncidentNumber, AlertIds)
+| mv-expand AlertIds to typeof(string)
+| join kind=leftouter(
+    SecurityAlert
+    | where TimeGenerated >= ago(90d)
+    | project
+        AnalyticsRuleId = tostring(todynamic(tostring(todynamic(ExtendedProperties)["Analytic Rule Ids"]))[0]),
+        AnalyticsRuleName = tostring(todynamic(ExtendedProperties)["Analytic Rule Name"]),
+        AlertName,
+        SystemAlertId
+) on $left.AlertIds == $right.SystemAlertId
+| distinct AnalyticsRuleName, AlertName

--- a/IncidentID2RuleName.txt
+++ b/IncidentID2RuleName.txt
@@ -2,7 +2,7 @@
 
 SecurityIncident
 | where TimeGenerated >= ago(90d)
-| where IncidentNumber == toint("<enter your Incident ID here>")
+| where IncidentNumber == toint("<enter your Incident ID here>") // Example: "118831"
 | summarize arg_max(TimeGenerated, IncidentNumber, AlertIds)
 | mv-expand AlertIds to typeof(string)
 | join kind=leftouter(


### PR DESCRIPTION
It was missing an ago() and in SecurityAlert there is no info about the SecurityIncident where the alert is.

What I meant in LinkedIn is an alert name and the rule name that generated that alert might not be the same (if you have specified so in the rule config).